### PR TITLE
Implemented Sprite::drawJpeg() + Sprite::drawGradientLine()

### DIFF
--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -187,13 +187,7 @@ void M5Display::drawBmpFile(fs::FS &fs, const char *path, uint16_t x, uint16_t y
 // void M5Display::drawBmp(fs::FS &fs, const char *path, uint16_t x, uint16_t y) {
 //   drawBmpFile(fs, path, x, y);
 // }
-/***************************************************
-  This library is written to be compatible with Adafruit's ILI9341
-  library and automatically detects the display type on ESP_WROVER_KITs
-  Earlier WROVERs had ILI9341, while newer releases have ST7789V
 
-  MIT license, all text above must be included in any redistribution
- ****************************************************/
 
 /*
  * JPEG
@@ -230,6 +224,7 @@ typedef struct {
   size_t len;
   size_t index;
   M5Display *tft;
+  TFT_eSprite *sprite;
   uint16_t outWidth;
   uint16_t outHeight;
 } jpg_file_decoder_t;

--- a/src/M5Display.h
+++ b/src/M5Display.h
@@ -7,14 +7,6 @@
   #include "utility/In_eSPI.h"
   #include "utility/Sprite.h"
 
-  typedef enum {
-    JPEG_DIV_NONE,
-    JPEG_DIV_2,
-    JPEG_DIV_4,
-    JPEG_DIV_8,
-    JPEG_DIV_MAX
-  } jpeg_div_t;
-
   class M5Display : public TFT_eSPI {
     public:
       M5Display();

--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -671,6 +671,20 @@ typedef enum {
   JPEG_DIV_MAX
 } jpeg_div_t;
 
+
+struct RGBColor {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  void set( uint8_t r_, uint8_t g_, uint8_t b_ ) {
+    r = r_; g = g_;  b = b_;
+  }
+  bool operator==(const RGBColor& color) {
+    return color.r == r && color.g == g && color.b == b;
+  }
+};
+
+
 // Class functions and variables
 class TFT_eSPI : public Print {
 

--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -15,7 +15,7 @@
 #ifndef _In_eSPIH_
 #define _In_eSPIH_
 
-#define TFT_ESPI_VERSION "1.4.5"
+#define TFT_ESPI_VERSION "1.4.21"
 
 //#define ESP32 //Just used to test ESP32 options
 
@@ -663,6 +663,8 @@ const PROGMEM fontinfo fontdata [] = {
 };
 
 
+typedef uint16_t (*getColorCallback)(uint16_t x, uint16_t y);
+
 typedef enum {
   JPEG_DIV_NONE,
   JPEG_DIV_2,
@@ -768,6 +770,7 @@ class TFT_eSPI : public Print {
 
            // Read the colour of a pixel at x,y and return value in 565 format 
   uint16_t readPixel(int32_t x0, int32_t y0);
+  void     setCallback(getColorCallback getCol);
 
            // The next functions can be used as a pair to copy screen blocks (or horizontal/vertical lines) to another location
            // Read a block of pixels to a data buffer, buffer is 16 bit and the array size must be at least w * h
@@ -900,6 +903,8 @@ class TFT_eSPI : public Print {
 #endif
 
   uint32_t lastColor = 0xFFFF;
+
+  getColorCallback getColor = nullptr;
 
  protected:
 

--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -663,6 +663,14 @@ const PROGMEM fontinfo fontdata [] = {
 };
 
 
+typedef enum {
+  JPEG_DIV_NONE,
+  JPEG_DIV_2,
+  JPEG_DIV_4,
+  JPEG_DIV_8,
+  JPEG_DIV_MAX
+} jpeg_div_t;
+
 // Class functions and variables
 class TFT_eSPI : public Print {
 

--- a/src/utility/In_eSPI_Setup.h
+++ b/src/utility/In_eSPI_Setup.h
@@ -295,7 +295,7 @@
 // #define SPI_FREQUENCY  80000000
 
 // Optional reduced SPI frequency for reading TFT
-#if defined( ARDUINO_ODROID_ESP32 ) || defined ( ARDUINO_ESP32_DEV )
+#if defined( ARDUINO_ODROID_ESP32 ) // || defined ( ARDUINO_ESP32_DEV )
   #define SPI_READ_FREQUENCY  20000000
 #else
   #define SPI_READ_FREQUENCY  16000000

--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -2010,4 +2010,253 @@ int16_t TFT_eSprite::printToSprite(int16_t x, int16_t y, uint16_t index)
 
   return this->gxAdvance[index];
 }
+
+
+/*
+ * JPEG
+ */
+
+
+#include "rom/tjpgd.h"
+
+#define jpgColor(c)                                                            \
+  (((uint16_t)(((uint8_t *)(c))[0] & 0xF8) << 8) |                             \
+   ((uint16_t)(((uint8_t *)(c))[1] & 0xFC) << 3) |                             \
+   ((((uint8_t *)(c))[2] & 0xF8) >> 3))
+
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_ERROR
+const char *jd_errors[] = {"Succeeded",
+                           "Interrupted by output function",
+                           "Device error or wrong termination of input stream",
+                           "Insufficient memory pool for the image",
+                           "Insufficient stream input buffer",
+                           "Parameter error",
+                           "Data format error",
+                           "Right format but not supported",
+                           "Not supported JPEG standard"};
+#endif
+
+typedef struct {
+  uint16_t x;
+  uint16_t y;
+  uint16_t maxWidth;
+  uint16_t maxHeight;
+  uint16_t offX;
+  uint16_t offY;
+  jpeg_div_t scale;
+  const void *src;
+  size_t len;
+  size_t index;
+  TFT_eSprite *tft;
+  uint16_t outWidth;
+  uint16_t outHeight;
+} jpg_file_decoder_t;
+
+static uint32_t jpgReadFile(JDEC *decoder, uint8_t *buf, uint32_t len) {
+  jpg_file_decoder_t *jpeg = (jpg_file_decoder_t *)decoder->device;
+  File *file = (File *)jpeg->src;
+  if (buf) {
+    return file->read(buf, len);
+  } else {
+    file->seek(len, SeekCur);
+  }
+  return len;
+}
+
+static uint32_t jpgRead(JDEC *decoder, uint8_t *buf, uint32_t len) {
+  jpg_file_decoder_t *jpeg = (jpg_file_decoder_t *)decoder->device;
+  if (buf) {
+    memcpy(buf, (const uint8_t *)jpeg->src + jpeg->index, len);
+  }
+  jpeg->index += len;
+  return len;
+}
+
+static uint32_t jpgWrite(JDEC *decoder, void *bitmap, JRECT *rect) {
+  jpg_file_decoder_t *jpeg = (jpg_file_decoder_t *)decoder->device;
+  uint16_t x = rect->left;
+  uint16_t y = rect->top;
+  uint16_t w = rect->right + 1 - x;
+  uint16_t h = rect->bottom + 1 - y;
+  uint16_t oL = 0, oR = 0;
+  uint8_t *data = (uint8_t *)bitmap;
+
+  if (rect->right < jpeg->offX) {
+    return 1;
+  }
+  if (rect->left >= (jpeg->offX + jpeg->outWidth)) {
+    return 1;
+  }
+  if (rect->bottom < jpeg->offY) {
+    return 1;
+  }
+  if (rect->top >= (jpeg->offY + jpeg->outHeight)) {
+    return 1;
+  }
+  if (rect->top < jpeg->offY) {
+    uint16_t linesToSkip = jpeg->offY - rect->top;
+    data += linesToSkip * w * 3;
+    h -= linesToSkip;
+    y += linesToSkip;
+  }
+  if (rect->bottom >= (jpeg->offY + jpeg->outHeight)) {
+    uint16_t linesToSkip = (rect->bottom + 1) - (jpeg->offY + jpeg->outHeight);
+    h -= linesToSkip;
+  }
+  if (rect->left < jpeg->offX) {
+    oL = jpeg->offX - rect->left;
+  }
+  if (rect->right >= (jpeg->offX + jpeg->outWidth)) {
+    oR = (rect->right + 1) - (jpeg->offX + jpeg->outWidth);
+  }
+
+  uint16_t pixBuf[32];
+  uint8_t pixIndex = 0;
+  uint16_t line;
+
+  //jpeg->tft->startWrite();
+  // jpeg->tft->setAddrWindow(x - jpeg->offX + jpeg->x + oL, y - jpeg->offY +
+  // jpeg->y, w - (oL + oR), h);
+  jpeg->tft->setWindow(x - jpeg->offX + jpeg->x + oL,
+                       y - jpeg->offY + jpeg->y,
+                       x - jpeg->offX + jpeg->x + oL + w - (oL + oR) - 1,
+                       y - jpeg->offY + jpeg->y + h - 1);
+
+  while (h--) {
+    data += 3 * oL;
+    line = w - (oL + oR);
+    while (line--) {
+      pixBuf[pixIndex++] = jpgColor(data);
+      data += 3;
+      if (pixIndex == 32) {
+        while( pixIndex > 0 ) {
+          pixIndex--;
+          jpeg->tft->pushColor( pixBuf[pixIndex] );
+        }
+      }
+    }
+    data += 3 * oR;
+  }
+  if (pixIndex) {
+    while( pixIndex > 0 ) {
+      pixIndex--;
+      jpeg->tft->pushColor( pixBuf[pixIndex] );
+    }
+  }
+  return 1;
+}
+
+static bool jpgDecode(jpg_file_decoder_t *jpeg,
+                      uint32_t (*reader)(JDEC *, uint8_t *, uint32_t)) {
+  static uint8_t work[3100];
+  JDEC decoder;
+
+  JRESULT jres = jd_prepare(&decoder, reader, work, 3100, jpeg);
+  if (jres != JDR_OK) {
+    log_e("jd_prepare failed! %s", jd_errors[jres]);
+    return false;
+  }
+
+  uint16_t jpgWidth = decoder.width / (1 << (uint8_t)(jpeg->scale));
+  uint16_t jpgHeight = decoder.height / (1 << (uint8_t)(jpeg->scale));
+
+  if (jpeg->offX >= jpgWidth || jpeg->offY >= jpgHeight) {
+    log_e("Offset Outside of JPEG size");
+    return false;
+  }
+
+  size_t jpgMaxWidth = jpgWidth - jpeg->offX;
+  size_t jpgMaxHeight = jpgHeight - jpeg->offY;
+
+  jpeg->outWidth =
+      (jpgMaxWidth > jpeg->maxWidth) ? jpeg->maxWidth : jpgMaxWidth;
+  jpeg->outHeight =
+      (jpgMaxHeight > jpeg->maxHeight) ? jpeg->maxHeight : jpgMaxHeight;
+
+  jres = jd_decomp(&decoder, jpgWrite, (uint8_t)jpeg->scale);
+  if (jres != JDR_OK) {
+    log_e("jd_decomp failed! %s", jd_errors[jres]);
+    return false;
+  }
+
+  return true;
+}
+
+void TFT_eSprite::drawJpg(const uint8_t *jpg_data, size_t jpg_len, uint16_t x,
+                        uint16_t y, uint16_t maxWidth, uint16_t maxHeight,
+                        uint16_t offX, uint16_t offY, jpeg_div_t scale) {
+  if ((x + maxWidth) > width() || (y + maxHeight) > height()) {
+    log_e("Bad dimensions given");
+    return;
+  }
+  if( getColorDepth() != 16 ) {
+    log_e("This sprite isn't using 16bit colors, aborting");
+    return;
+  }
+
+  jpg_file_decoder_t jpeg;
+
+  if (!maxWidth) {
+    maxWidth = width() - x;
+  }
+  if (!maxHeight) {
+    maxHeight = height() - y;
+  }
+
+  jpeg.src = jpg_data;
+  jpeg.len = jpg_len;
+  jpeg.index = 0;
+  jpeg.x = x;
+  jpeg.y = y;
+  jpeg.maxWidth = maxWidth;
+  jpeg.maxHeight = maxHeight;
+  jpeg.offX = offX;
+  jpeg.offY = offY;
+  jpeg.scale = scale;
+  jpeg.tft = this;
+
+  jpgDecode(&jpeg, jpgRead);
+}
+
+void TFT_eSprite::drawJpgFile(fs::FS &fs, const char *path, uint16_t x, uint16_t y,
+                            uint16_t maxWidth, uint16_t maxHeight, uint16_t offX,
+                            uint16_t offY, jpeg_div_t scale) {
+  if ((x + maxWidth) > width() || (y + maxHeight) > height()) {
+    log_e("Bad dimensions given");
+    return;
+  }
+
+  File file = fs.open(path);
+  if (!file) {
+    log_e("Failed to open file for reading");
+    return;
+  }
+
+  jpg_file_decoder_t jpeg;
+
+  if (!maxWidth) {
+    maxWidth = width() - x;
+  }
+  if (!maxHeight) {
+    maxHeight = height() - y;
+  }
+
+  jpeg.src = &file;
+  jpeg.len = file.size();
+  jpeg.index = 0;
+  jpeg.x = x;
+  jpeg.y = y;
+  jpeg.maxWidth = maxWidth;
+  jpeg.maxHeight = maxHeight;
+  jpeg.offX = offX;
+  jpeg.offY = offY;
+  jpeg.scale = scale;
+  jpeg.tft = this;
+
+  jpgDecode(&jpeg, jpgReadFile);
+
+  file.close();
+}
+
+
 #endif

--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -474,7 +474,13 @@ void TFT_eSprite::pushSprite(int32_t x, int32_t y)
 {
   if (!_created) return;
 
-  if (_bpp == 16) _tft->pushImage(x, y, _iwidth, _iheight, _img );
+  if (_bpp == 16)
+  {
+    bool oldSwapBytes = _tft->getSwapBytes();
+    _tft->setSwapBytes(false);
+    _tft->pushImage(x, y, _iwidth, _iheight, _img );
+    _tft->setSwapBytes(oldSwapBytes);
+  }
 
   else _tft->pushImage(x, y, _dwidth, _dheight, _img8, (bool)(_bpp == 8));
 }
@@ -488,7 +494,13 @@ void TFT_eSprite::pushSprite(int32_t x, int32_t y, uint16_t transp)
 {
   if (!_created) return;
 
-  if (_bpp == 16) _tft->pushImage(x, y, _iwidth, _iheight, _img, transp );
+  if (_bpp == 16)
+  {
+    bool oldSwapBytes = _tft->getSwapBytes();
+    _tft->setSwapBytes(false);
+    _tft->pushImage(x, y, _iwidth, _iheight, _img, transp );
+    _tft->setSwapBytes(oldSwapBytes);
+  }
   else if (_bpp == 8)
   {
     transp = (uint8_t)((transp & 0xE000)>>8 | (transp & 0x0700)>>6 | (transp & 0x0018)>>3);
@@ -564,18 +576,18 @@ void  TFT_eSprite::pushImage(int32_t x, int32_t y, int32_t w, int32_t h, uint16_
   int32_t  xs = x;
   int32_t  ys = y;
 
-  uint32_t ws = w;
-  uint32_t hs = h;
+  int32_t ws = w;
+  int32_t hs = h;
 
-  if (x < 0) { xo = -x; xs = 0; }
-  if (y < 0) { yo = -y; ys = 0; }
+  if (x < 0) { xo = -x; ws += x; xs = 0; }
+  if (y < 0) { yo = -y; hs += y; ys = 0; }
 
-  if (xs + w >= _iwidth)  ws = _iwidth  - xs;
-  if (ys + h >= _iheight) hs = _iheight - ys;
+  if (xs + ws >= (int32_t)_iwidth)  ws = _iwidth  - xs;
+  if (ys + hs >= (int32_t)_iheight) hs = _iheight - ys;
 
   if (_bpp == 16) // Plot a 16 bpp image into a 16 bpp Sprite
   {
-    for (uint32_t yp = yo; yp < yo + hs; yp++)
+    for (int32_t yp = yo; yp < yo + hs; yp++)
     {
       x = xs;
       for (uint32_t xp = xo; xp < xo + ws; xp++)
@@ -590,10 +602,10 @@ void  TFT_eSprite::pushImage(int32_t x, int32_t y, int32_t w, int32_t h, uint16_
   }
   else if (_bpp == 8) // Plot a 16 bpp image into a 8 bpp Sprite
   {
-    for (uint32_t yp = yo; yp < yo + hs; yp++)
+    for (int32_t yp = yo; yp < yo + hs; yp++)
     {
       x = xs;
-      for (uint32_t xp = xo; xp < xo + ws; xp++)
+      for (int32_t xp = xo; xp < xo + ws; xp++)
       {
         uint16_t color = data[xp + yp * w];
         if(_iswapBytes) color = color<<8 | color>>8;
@@ -660,21 +672,21 @@ void  TFT_eSprite::pushImage(int32_t x, int32_t y, int32_t w, int32_t h, const u
   int32_t  xs = x;
   int32_t  ys = y;
 
-  uint32_t ws = w;
-  uint32_t hs = h;
+  int32_t ws = w;
+  int32_t hs = h;
 
-  if (x < 0) { xo = -x; xs = 0; }
-  if (y < 0) { yo = -y; ys = 0; }
+  if (x < 0) { xo = -x; ws += x; xs = 0; }
+  if (y < 0) { yo = -y; hs += y; ys = 0; }
 
-  if (xs + w >= _iwidth)  ws = _iwidth  - xs;
-  if (ys + h >= _iheight) hs = _iheight - ys;
+  if (xs + ws >= (int32_t)_iwidth)  ws = _iwidth  - xs;
+  if (ys + hs >= (int32_t)_iheight) hs = _iheight - ys;
 
   if (_bpp == 16) // Plot a 16 bpp image into a 16 bpp Sprite
   {
-    for (uint32_t yp = yo; yp < yo + hs; yp++)
+    for (int32_t yp = yo; yp < yo + hs; yp++)
     {
       x = xs;
-      for (uint32_t xp = xo; xp < xo + ws; xp++)
+      for (int32_t xp = xo; xp < xo + ws; xp++)
       {
         uint16_t color = pgm_read_word(data + xp + yp * w);
         if(!_iswapBytes) color = color<<8 | color>>8;
@@ -687,10 +699,10 @@ void  TFT_eSprite::pushImage(int32_t x, int32_t y, int32_t w, int32_t h, const u
 
   else if (_bpp == 8) // Plot a 16 bpp image into a 8 bpp Sprite
   {
-    for (uint32_t yp = yo; yp < yo + hs; yp++)
+    for (int32_t yp = yo; yp < yo + hs; yp++)
     {
       x = xs;
-      for (uint32_t xp = xo; xp < xo + ws; xp++)
+      for (int32_t xp = xo; xp < xo + ws; xp++)
       {
         uint16_t color = pgm_read_word(data + xp + yp * w);
         if(_iswapBytes) color = color<<8 | color>>8;
@@ -731,7 +743,7 @@ void  TFT_eSprite::pushImage(int32_t x, int32_t y, int32_t w, int32_t h, const u
         uint8_t pbyte = pgm_read_byte(pdata++);
         for (uint8_t xc = 0; xc < 8; xc++)
         {
-          if (xp+xc<w) drawPixel(x+xp+xc, y+yp, (pbyte<<xc) & 0x80);
+          if (xp+xc<(uint32_t)w) drawPixel(x+xp+xc, y+yp, (pbyte<<xc) & 0x80);
         }
       }
     }
@@ -766,22 +778,8 @@ bool TFT_eSprite::getSwapBytes(void)
 *************************************************************************************x*/
 void TFT_eSprite::setWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
 {
-  bool duff_coord = false;
 
-  if (x0 > x1) swap_coord(x0, x1);
-  if (y0 > y1) swap_coord(y0, y1);
-
-  if (x0 < 0) x0 = 0;
-  if (x0 >= _iwidth) duff_coord = true;
-  if (x1 < 0) x1 = 0;
-  if (x1 >= _iwidth) x1 = _iwidth - 1;
-
-  if (y0 < 0) y0 = 0;
-  if (y0 >= _iheight) duff_coord = true;
-  if (y1 < 0) y1 = 0;
-  if (y1 >= _iheight) y1 = _iheight - 1;
-
-  if (duff_coord)
+  if ((x0 >= _iwidth) || (x1 < 0) || (y0 >= _iheight) || (y1 < 0))
   { // Point to that extra "off screen" pixel
     _xs = 0;
     _ys = _iheight;
@@ -790,6 +788,10 @@ void TFT_eSprite::setWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
   }
   else
   {
+    if (x0 < 0) x0 = 0;
+    if (x1 >= _iwidth) x1 = _iwidth - 1;
+    if (y0 < 0) y0 = 0;
+    if (y1 >= _iheight) y1 = _iheight - 1;
     _xs = x0;
     _ys = y0;
     _xe = x1;
@@ -891,8 +893,8 @@ void TFT_eSprite::setScrollRect(int32_t x, int32_t y, int32_t w, int32_t h, uint
 {
   if ((x >= _iwidth) || (y >= _iheight) || !_created ) return;
 
-  if (x < 0) x = 0;
-  if (y < 0) y = 0;
+  if (x < 0) { w += x; x = 0; }
+  if (y < 0) { h += y; y = 0; }
 
   if ((x + w) > _iwidth ) w = _iwidth  - x;
   if ((y + h) > _iheight) h = _iheight - y;
@@ -1098,21 +1100,19 @@ void TFT_eSprite::drawPixel(int32_t x, int32_t y, uint32_t color)
 {
   // Range checking
   if ((x < 0) || (y < 0) || !_created) return;
+  if ((x >= _iwidth) || (y >= _iheight)) return;
 
   if (_bpp == 16)
   {
-    if ((x >= _iwidth) || (y >= _iheight)) return;
     color = (color >> 8) | (color << 8);
     _img[x+y*_iwidth] = (uint16_t) color;
   }
   else if (_bpp == 8)
   {
-    if ((x >= _iwidth) || (y >= _iheight)) return;
     _img8[x+y*_iwidth] = (uint8_t)((color & 0xE000)>>8 | (color & 0x0700)>>6 | (color & 0x0018)>>3);
   }
   else // 1 bpp
   {
-    if ((x >= _dwidth) || (y >= _dheight)) return;
     if (_rotation == 1)
     {
       uint16_t tx = x;

--- a/src/utility/Sprite.h
+++ b/src/utility/Sprite.h
@@ -60,7 +60,13 @@ class TFT_eSprite : public TFT_eSPI {
            drawFastVLine(int32_t x, int32_t y, int32_t h, uint32_t color),
            drawFastHLine(int32_t x, int32_t y, int32_t w, uint32_t color),
 
+           drawGradientLine(int32_t x0, int32_t y0, int32_t x1, int32_t y1, RGBColor colorstart, RGBColor colorend),
+           drawGradientHLine(int32_t x, int32_t y, int32_t w, RGBColor colorstart, RGBColor colorend),
+           drawGradientVLine( int32_t x, int32_t y, int32_t h, RGBColor colorstart, RGBColor colorend),
+
            fillRect(int32_t x, int32_t y, int32_t w, int32_t h, uint32_t color);
+
+  RGBColor colorAt( int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBColor colorstart, RGBColor colorend );
 
            // Set the sprite text cursor position for print class (does not change the TFT screen cursor)
            //setCursor(int16_t x, int16_t y);

--- a/src/utility/Sprite.h
+++ b/src/utility/Sprite.h
@@ -4,6 +4,8 @@
 // from the TFT_eSPI class. Some functions are overridden by this class so that the
 // graphics are written to the Sprite rather than the TFT.
 ***************************************************************************************/
+#include <FS.h>
+#include <SPI.h>
 #include "In_eSPI.h"
 
 class TFT_eSprite : public TFT_eSPI {
@@ -87,6 +89,23 @@ class TFT_eSprite : public TFT_eSPI {
   void     pushImage(int32_t x0, int32_t y0, int32_t w, int32_t h, uint16_t *data);
   void     pushImage(int32_t x0, int32_t y0, int32_t w, int32_t h, const uint16_t *data);
 
+  
+  void drawJpg(const uint8_t *jpg_data, size_t jpg_len, uint16_t x = 0,
+              uint16_t y = 0, uint16_t maxWidth = 0, uint16_t maxHeight = 0,
+              uint16_t offX = 0, uint16_t offY = 0,
+              jpeg_div_t scale = JPEG_DIV_NONE);
+
+  void drawJpg(fs::FS &fs, const char *path, uint16_t x = 0, uint16_t y = 0,
+                uint16_t maxWidth = 0, uint16_t maxHeight = 0,
+                uint16_t offX = 0, uint16_t offY = 0,
+                jpeg_div_t scale = JPEG_DIV_NONE);
+
+  void drawJpgFile(fs::FS &fs, const char *path, uint16_t x = 0, uint16_t y = 0,
+                uint16_t maxWidth = 0, uint16_t maxHeight = 0,
+                uint16_t offX = 0, uint16_t offY = 0,
+                jpeg_div_t scale = JPEG_DIV_NONE);
+
+  
            // Swap the byte order for pushImage() - corrects different image endianness
   void     setSwapBytes(bool swap);
   bool     getSwapBytes(void);


### PR DESCRIPTION
drawJpeg
------------
How?
All `*jpg*` methods from M5Display have been shadowed into `Sprite`, it shouldn't be too hard to replicate this for BMP and PNG alghough it's unlikely there's a need for that.

Why?
drawJpeg() was only accessible from M5Display, making it a pain in the ass to put a jpeg image into a Sprite.

drawGradientLine
----------------------
How?
Available only in with sprites, to allow easier display driver switching. Also the implementation isn't focused on fast rendering.

Why?
Because all drawLine() methods are optimized for single color drawing, and it feels excessive to always use background images when a nice gradient can be produced.

Fixes
-------

Backported all fixes from https://github.com/Bodmer/TFT_eSPI since July 2019

