### PR TITLE
Bugfixes and features

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -744,6 +744,9 @@ uint16_t TFT_eSPI::readPixel(int32_t x0, int32_t y0)
 
   // Dummy read to throw away don't care value
   tft_Read_8();
+  #if defined (WROVER_KIT_LCD_DRIVER)
+    tft_Read_8(); // Extra dummy read for WROVER_KIT_LCD_DRIVER (and possibly other ST7789)
+  #endif
   
   //#if !defined (ILI9488_DRIVER)
 
@@ -917,6 +920,9 @@ void TFT_eSPI::readRect(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t *da
 
   // Dummy read to throw away don't care value
   tft_Read_8();
+  #if defined (WROVER_KIT_LCD_DRIVER)
+    tft_Read_8(); // Extra dummy read for WROVER_KIT_LCD_DRIVER (and possibly other ST7789)
+  #endif
 
   // Read window pixel 24 bit RGB values
   uint32_t len = w * h;
@@ -940,8 +946,13 @@ void TFT_eSPI::readRect(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t *da
 
   #endif
 
-    // Swapped colour byte order for compatibility with pushRect()
-    *data++ = (r & 0xF8) | (g & 0xE0) >> 5 | (b & 0xF8) << 5 | (g & 0x1C) << 11;
+    #if defined (WROVER_KIT_LCD_DRIVER)
+      // pushRect() is deprecated so don't care
+      *data++ = color565(r, g, b);
+    #else
+      // Swapped colour byte order for compatibility with pushRect()
+      *data++ = (r & 0xF8) | (g & 0xE0) >> 5 | (b & 0xF8) << 5 | (g & 0x1C) << 11;
+    #endif
   }
 
   CS_H;
@@ -1578,10 +1589,12 @@ void  TFT_eSPI::readRectRGB(int32_t x0, int32_t y0, int32_t w, int32_t h, uint8_
 
   // Dummy read to throw away don't care value
   tft_Read_8();
-
+  #if defined (WROVER_KIT_LCD_DRIVER)
+    tft_Read_8(); // Extra dummy read for WROVER_KIT_LCD_DRIVER (and possibly other ST7789)
+  #endif
   // Read window pixel 24 bit RGB values, buffer must be set in sketch to 3 * w * h
   uint32_t len = w * h;
-  while (len--) {
+  while (len-->0) {
 
   #if !defined (ILI9488_DRIVER)
 

--- a/src/utility/ScreenShot.cpp
+++ b/src/utility/ScreenShot.cpp
@@ -49,23 +49,25 @@ void ScreenShotService::init( M5Display *tft, fs::FS &fileSystem ) {
 }
 
 
-bool ScreenShotService::begin() {
+bool ScreenShotService::begin( bool ifPsram ) {
   if( _begun ) return true;
   if( !displayCanReadPixels() ) {
     log_e( "readPixel() test failed, screenshots are disabled" );
     return false;
   }
-  if( psramInit() ) {
-    rgbBuffer = (uint8_t*)ps_calloc( _tft->width()*_tft->height()*3, sizeof( uint8_t ) );
+  if( ifPsram && psramInit() ) {
+    log_w("Will attempt to allocate psram for screenshots");
+    rgbBuffer = (uint8_t*)ps_calloc( (_tft->width()*_tft->height()*3)+1, sizeof( uint8_t ) );
   } else {
+    log_w("Will attempt to allocate ram for screenshots");
     // attempt to allocate anyway, and use BMP stream on failure
-    rgbBuffer = (uint8_t*)calloc( _tft->width()*_tft->height()*3, sizeof( uint8_t ) );
+    rgbBuffer = (uint8_t*)calloc( (_tft->width()*_tft->height()*3)+1, sizeof( uint8_t ) );
   }
   if( rgbBuffer != NULL ) {
-    log_i( "ScreenShot Service can use JPG capture" );
-    JPEGEncoder.begin();
+    log_w( "ScreenShot Service can use JPG capture" );
+    JPEGEncoder.begin( ifPsram );
   } else {
-    log_i( "ScreenShot Service can use BMP capture" );
+    log_w( "ScreenShot Service can use BMP capture" );
     jpegCapture = false;
   }
   _begun = true;
@@ -73,53 +75,75 @@ bool ScreenShotService::begin() {
 }
 
 
+
+
 bool ScreenShotService::displayCanReadPixels() {
-  uint16_t value_in = TFT_BLUE;
-  _tft->fillRect( 10, 10, 50, 50, value_in ); //  <----- Test color
-  uint16_t value_out = _tft->readPixel( 30,30 );
-  _tft->clear();
-  log_i( "readPixel() test, expected:0x%02x, got: 0x%02x", value_in, value_out );
+  uint16_t value_initial = _tft->readPixel( 30,30 );
+  uint8_t r = 64, g = 255, b = 128; // scan color
+  uint16_t value_in = _tft->color565(r, g, b);
+  uint16_t value_out;
+  byte testnum = 0;
+
+  log_w( "Testing display#%04x", TFT_DRIVER );
+
+  _tft->drawPixel( 30, 30, value_in ); //  <----- Test color
+  value_out = _tft->readPixel( 30,30 );
+  log_w( "test#%d: readPixel(as rgb565), expected:0x%04x, got: 0x%04x", testnum++, value_in, value_out );
   if( value_in == value_out ) {
     readPixelSuccess = true;
+    _tft->drawPixel( 30, 30, value_initial );
     return true;
   }
   return false;
 }
 
 
-void ScreenShotService::snap( const char* name ) {
+void ScreenShotService::snap( const char* name, bool displayAfter ) {
   if( readPixelSuccess == false ) {
     log_e( "This TFT is unsupported, or it hasn't been tested yet" );
     return;
   }
   if( jpegCapture ) { // enough ram allocated?
-    snapJPG( name );
+    snapJPG( name, displayAfter );
   } else { // BMP capture
-    snapBMP( name );
+    snapBMP( name, displayAfter );
   }
   return;
 }
 
 
-void ScreenShotService::snapJPG( const char* name ) {
+void ScreenShotService::snapJPG( const char* name, bool displayAfter ) {
   if( !jpegCapture ) return;
-  _tft->readRectRGB( 0, 0, _tft->width(), _tft->height(), rgbBuffer );
+
   genFileName( name, "jpg" );
+
+  _tft->readRectRGB( 0, 0, _tft->width(), _tft->height(), rgbBuffer );
+
   if ( !JPEGEncoder.encodeToFile( fileName, _tft->width(), _tft->height(), 3 /*3=RGB,4=RGBA*/, rgbBuffer ) ) {
     log_e( "[ERROR] Could not write JPG file to: %s", fileName );
   } else {
     Serial.printf( "Screenshot saved as %s\n", fileName );
+    if( displayAfter ) {
+      snapAnimation();
+      _tft->drawJpgFile( *_fileSystem, fileName, 0, 0, _tft->width(), _tft->height(), 0, 0, JPEG_DIV_NONE );
+      delay(5000);
+    }
   }
 }
 
 
-void ScreenShotService::snapBMP( const char* name ) {
+void ScreenShotService::snapBMP( const char* name, bool displayAfter ) {
   genFileName( name, "bmp" );
   if( !BMPEncoder.encodeToFile( fileName, _tft->width(), _tft->height() ) )  {
     log_e( "[ERROR] Could not write BMP file to: %s", fileName );
   } else {
     Serial.printf( "Screenshot saved as %s\n", fileName );
-  } 
+    if( displayAfter ) {
+      snapAnimation();
+      _tft->drawBmpFile( *_fileSystem, fileName, 0, 0 );
+      delay(5000);
+    }
+  }
 }
 
 
@@ -155,7 +179,16 @@ void ScreenShotService::genFileName( const char* name, const char* extension ) {
 }
 
 
-
+void ScreenShotService::snapAnimation() {
+  for( byte i = 0; i<16; i++ ) {
+    _tft->drawRect(0, 0, _tft->width()-1, _tft->height()-1, WHITE);
+    delay(20);
+    _tft->drawRect(0, 0, _tft->width()-1, _tft->height()-1, BLACK);
+    delay(20);
+  }
+  _tft->clear();
+  delay(150);
+}
 
 
 

--- a/src/utility/ScreenShot.h
+++ b/src/utility/ScreenShot.h
@@ -44,15 +44,15 @@ class ScreenShotService {
     ~ScreenShotService();
 
     void init( M5Display *tft, fs::FS &fileSystem );
-    bool begin(); // ram test and allocation
+    bool begin( bool ifPsram = true ); // ram test and allocation
     /*
      *  M5.ScreenShot.snap() => /jpg/screenshot-YYYY-MM-DD_HH-MM-SS.jpg 
      *  M5.ScreenShot.snap("my-namespace") => /jpg/my-namespace-YYYY-MM-DD_HH-MM-SS.jpg 
      *  M5.ScreenShot.snap("/path/to/my-file.jpg") => /path/to/my-file.jpg
      */
-    void snap(    const char* name = "screenshot" );
-    void snapJPG( const char* name = "screenshot" );
-    void snapBMP( const char* name = "screenshot" );  
+    void snap(    const char* name = "screenshot", bool displayAfter = false );
+    void snapJPG( const char* name = "screenshot", bool displayAfter = false );
+    void snapBMP( const char* name = "screenshot", bool displayAfter = false );
 
     bool readPixelSuccess  = false; // result of tft pixel read test
     bool jpegCapture       = true; // default yes until tested, BMP capture will be used if not enough ram is available
@@ -60,20 +60,22 @@ class ScreenShotService {
   private:
 
     bool        _begun         = false; // prevent begin() from being called more than once
-    uint8_t*    rgbBuffer      = NULL; // used for jpeg only, bmp has his own
+
     char        fileName[255]  = {0};
     char        folderName[32] = {0};
 
     M5Display* _tft;
     fs::FS *   _fileSystem;
 
+    void        genFileName( const char* name, const char* extension );
+    void        checkFolder( const char* path );
+    void        snapAnimation();
+    bool        displayCanReadPixels();
 
     JPEG_Encoder JPEGEncoder;
     BMP_Encoder  BMPEncoder;
 
-    void        genFileName( const char* name, const char* extension );
-    void        checkFolder( const char* path );
-    bool        displayCanReadPixels();
+    uint8_t*    rgbBuffer      = NULL; // used for jpeg only, bmp has his own
 
 
 }; // end class

--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -97,10 +97,7 @@ void* TFT_eSprite::createSprite(int16_t w, int16_t h, uint8_t frames)
 *************************************************************************************x*/
 TFT_eSprite::~TFT_eSprite()
 {
-  if( _created ) {
-    _created = false;
-    deleteSprite();
-  }
+  deleteSprite();
 }
 
 

--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -97,7 +97,10 @@ void* TFT_eSprite::createSprite(int16_t w, int16_t h, uint8_t frames)
 *************************************************************************************x*/
 TFT_eSprite::~TFT_eSprite()
 {
-  deleteSprite();
+  if( _created ) {
+    _created = false;
+    deleteSprite();
+  }
 }
 
 

--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -101,6 +101,11 @@ TFT_eSprite::~TFT_eSprite()
 }
 
 
+void TFT_eSprite::setPsram( bool enabled ) {
+  _usePsram = enabled;
+}
+
+
 /***************************************************************************************
 ** Function name:           callocSprite
 ** Description:             Allocate a memory area for the Sprite and return pointer
@@ -117,7 +122,7 @@ void* TFT_eSprite::callocSprite(int16_t w, int16_t h, uint8_t frames)
   {
 
 #if defined (ESP32) && defined (CONFIG_SPIRAM_SUPPORT)
-    if ( psramFound() ) ptr8 = ( uint8_t*) ps_calloc(w * h + 1, sizeof(uint16_t));
+    if ( psramFound() && _usePsram ) ptr8 = ( uint8_t*) ps_calloc(w * h + 1, sizeof(uint16_t));
     else
 #endif
     ptr8 = ( uint8_t*) calloc(w * h + 1, sizeof(uint16_t));
@@ -126,7 +131,7 @@ void* TFT_eSprite::callocSprite(int16_t w, int16_t h, uint8_t frames)
   else if (_bpp == 8)
   {
 #if defined (ESP32) && defined (CONFIG_SPIRAM_SUPPORT)
-    if ( psramFound() ) ptr8 = ( uint8_t*) ps_calloc(w * h + 1, sizeof(uint8_t));
+    if ( psramFound() && _usePsram ) ptr8 = ( uint8_t*) ps_calloc(w * h + 1, sizeof(uint8_t));
     else
 #endif
     ptr8 = ( uint8_t*) calloc(w * h + 1, sizeof(uint8_t));
@@ -145,7 +150,7 @@ void* TFT_eSprite::callocSprite(int16_t w, int16_t h, uint8_t frames)
     if (frames > 2) frames = 2; // Currently restricted to 2 frame buffers
     if (frames < 1) frames = 1;
 #if defined (ESP32) && defined (CONFIG_SPIRAM_SUPPORT)
-    if ( psramFound() ) ptr8 = ( uint8_t*) ps_calloc(frames * (w>>3) * h + frames, sizeof(uint8_t));
+    if ( psramFound() && _usePsram ) ptr8 = ( uint8_t*) ps_calloc(frames * (w>>3) * h + frames, sizeof(uint8_t));
     else
 #endif
     ptr8 = ( uint8_t*) calloc(frames * (w>>3) * h + frames, sizeof(uint8_t));

--- a/src/utility/Sprite.h
+++ b/src/utility/Sprite.h
@@ -15,7 +15,6 @@ class TFT_eSprite : public TFT_eSPI {
   TFT_eSprite(TFT_eSPI *tft); // Constructor
   virtual ~TFT_eSprite();
 
-
            // Create a sprite of width x height pixels, return a pointer to the RAM area
            // Sketch can cast returned value to (uint16_t*) for 16 bit depth if needed
            // RAM required is 1 byte per pixel for 8 bit colour depth, 2 bytes for 16 bit
@@ -136,6 +135,7 @@ class TFT_eSprite : public TFT_eSPI {
   void     printToSprite(String string);
   void     printToSprite(char *cbuffer, uint16_t len);
   int16_t  printToSprite(int16_t x, int16_t y, uint16_t index);
+  void     setPsram( bool enabled );
 
  private:
 
@@ -157,6 +157,7 @@ class TFT_eSprite : public TFT_eSPI {
 
   bool     _created;    // A Sprite has been created and memory reserved
   bool     _gFont = false; 
+  bool     _usePsram = true; // use Psram if available
 
 //  int32_t  _icursor_x, _icursor_y;
   uint8_t  _rotation = 0;

--- a/src/utility/TinyJPEGEncoder.cpp
+++ b/src/utility/TinyJPEGEncoder.cpp
@@ -188,8 +188,8 @@ void JPEG_Encoder::init( fs::FS &fileSystem ) {
 }
 
 
-void JPEG_Encoder::begin() {
-  if( psramInit() ) {
+void JPEG_Encoder::begin( bool ifPsram ) {
+  if( ifPsram && psramInit() ) {
     huffsize = (uint8_t**)ps_calloc(4*257, sizeof(uint8_t));
     for(byte i=0; i<4; i++) {
       huffsize[i] = (uint8_t*)ps_calloc(257, sizeof(uint8_t) );

--- a/src/utility/TinyJPEGEncoder.h
+++ b/src/utility/TinyJPEGEncoder.h
@@ -195,7 +195,7 @@ class JPEG_Encoder {
     uint16_t** huffcode = NULL;
 
     void       init( fs::FS &fileSystem );
-    void       begin();
+    void       begin( bool ifPsram = true );
     int        encodeToFile( const char* dest_path, const int width, const int height, const int numComponents, const unsigned char* src_data );
     int        encodeWithFunc( writeFunc* func, fs::File jpegFile, const int quality, const int width, const int height, const int numComponents, const unsigned char* src_data );
 


### PR DESCRIPTION
**Fix:** 
 - **TFT_eSPI bugfix** : `readRect()`, `readRectRGB()` and `readPixel()` were returning 1-byte shifted RGB data with ST7789 (WROVER_KIT 4.2).
    !! WROVER_KIT 4.1 using ILI9341 is untested since it needs the removal of the zero-ohm smd resistor that prevents SD and TFT to work together !!


**Features:**
 - **Sprite** `setPsram( bool )` because animating from PSRam is sometimes much slower, disabling it for a given sprite can be a life saver. It is also a good tool to tests code portability.
   * `sprite.setPsram( false )` must be called before `sprite.createSprite()` in order to be effective.
<br>

 - **ScreenShotService** `snap*()` methods have a second bool argument `displayAfter` (default=false)
   * `M5.Screenshot.snap("blah", true)` will display the screenshot after being saved on the SD

<br>

 - **ScreenShotService** `begin()` has a bool argument `ifPsram` (default=true)
   * `M5.ScreenShot.begin( true )`: This will test PSRam support and enable it if available, it is only useful for JPEG rendering since the driver needs the full array of pixels to calculate the palette.
   * `M5.ScreenShot.begin( false )`: This is useful in situations where the PSRam is already allocated by the running application or should be left free for other uses Setting this value to false will disable JPEG rendering unless enough heap (e.g width*height*3 = 320*240*3 = 230400 bytes) is available.