### PR TITLE
Add ARDUINO_M5STACK_FIRE

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -288,7 +288,7 @@
   #define BUTTON_B_PIN -1
   #define BUTTON_C_PIN -1
 
-#elif defined( ARDUINO_M5Stack_Core_ESP32 ) // m5stack classic/fire
+#elif defined( ARDUINO_M5Stack_Core_ESP32 ) || defined( ARDUINO_M5STACK_FIRE) // m5stack classic/fire
 
   #define HAS_IP5306
 

--- a/src/ESP32-Chimera-Core.h
+++ b/src/ESP32-Chimera-Core.h
@@ -256,7 +256,7 @@
         #endif
 
 
-        #if defined( ARDUINO_M5Stack_Core_ESP32 )
+        #if defined( ARDUINO_M5Stack_Core_ESP32 ) || defined( ARDUINO_M5STACK_FIRE )
           #define HAS_POWER
             POWER Power;
         #endif


### PR DESCRIPTION
The build option ARDUINO_M5STACK_FIRE was not supported, so it has been added.